### PR TITLE
Added Scrub Delay

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -358,7 +358,7 @@ const FeaturesSection = () => {
       align="left"
       columns={[1, 2, 3]}
       iconSize={4}
-      scrub={true}
+      scrub={1}
       duration={1}
       stagger={0.1}
       delay={0}

--- a/components/features/features.tsx
+++ b/components/features/features.tsx
@@ -38,7 +38,7 @@ export interface FeaturesProps
   reveal?: React.FC<any>
   iconSize?: SystemProps['boxSize']
   innerWidth?: SystemProps['maxW']
-  scrub?: boolean
+  scrub?: boolean | number
   duration?: number
   stagger?: number
   delay?: number


### PR DESCRIPTION
This pull request updates the way the `scrub` prop is handled in the features section to allow for greater flexibility. Instead of only accepting a boolean, `scrub` can now be a boolean or a number, and its usage has been updated accordingly.

Features section prop improvements:

* Changed the type of the `scrub` prop in the `FeaturesProps` interface from `boolean` to `boolean | number` to support more flexible animation controls.
* Updated the `FeaturesSection` component to use a numeric value (`scrub={1}`) instead of a boolean for the `scrub` prop, reflecting the new flexibility.